### PR TITLE
Fix: Changed the clientheight value from 1 to 2 on Typing page file

### DIFF
--- a/src/pages/Typing/Typing.js
+++ b/src/pages/Typing/Typing.js
@@ -405,7 +405,7 @@ function Typing() {
             <Title>
               <h3>{script_data?.scriptType} - {script_data?.scriptCategory}</h3>
               <h4 ref={titleRef} onClick={(e)=>console.log(e.target.clientHeight, e.target.offsetHeight, e.target.scrollHeight)}>{script_data?.scriptTitle}</h4>
-              {titleRef.current?.clientHeight+1 < titleRef.current?.scrollHeight && (
+              {titleRef.current?.clientHeight+2 < titleRef.current?.scrollHeight && (
                 <TitleMore>
                   <span></span>
                   <div>


### PR DESCRIPTION
To fix the position of the plus button that displays the entire title